### PR TITLE
修改部分type定义的类型为interface

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,4 +1,4 @@
-export type QiankunProps = {
+export interface QiankunProps {
   container?: HTMLElement;
   [x: string]: any;
 };
@@ -9,7 +9,7 @@ export type QiankunLifeCycle = {
   unmount: (props: QiankunProps) => void | Promise<void>;
 };
 
-export type QiankunWindow = {
+export interface QiankunWindow {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __POWERED_BY_QIANKUN__?: boolean;
   [x: string]: any


### PR DESCRIPTION
将可扩展类型的定义从type改为interface，方便用户扩展类型

env.d.ts
``` typescript
import 'vite-plugin-qiankun/dist/helper'

declare module 'vite-plugin-qiankun/dist/helper' {
  interface QiankunWindow {
    test: boolean
  }
}
```

main.ts
``` typescript
import {  qiankunWindow } from 'vite-plugin-qiankun/dist/helper'

qiankunWindow.test = true
```