### PR TITLE
feat: adapt to vite3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ const htmlPlugin: PluginFn = (qiankunName, microOption = {}) => {
     },
     transformIndexHtml (html: string) {
       const $ = cheerio.load(html)
-      const moduleTags = $('script[type=module]')
+      const moduleTags = $('body script[type=module]')
       if (!moduleTags || !moduleTags.length) {
         return
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ const htmlPlugin: PluginFn = (qiankunName, microOption = {}) => {
     },
     transformIndexHtml (html: string) {
       const $ = cheerio.load(html)
-      const moduleTags = $('body script[type=module]')
+      const moduleTags = $('body script[type=module], head script[crossorigin=""]')
       if (!moduleTags || !moduleTags.length) {
         return
       }


### PR DESCRIPTION
vite3 中有如下变更：

> transformIndexHtml 现在会从更早的插件处获取到正确的内容，因此，现在注入的标签的顺序与预期的一样。

related: https://cn.vitejs.dev/guide/migration.html#advanced